### PR TITLE
fix: task receives pipeline argument, not document

### DIFF
--- a/src/commands/insert.ts
+++ b/src/commands/insert.ts
@@ -32,7 +32,7 @@ export function insertOne(
   return cy
     .task('insertOne', {
       uri: args.uri,
-      document: document,
+      pipeline: document,
       collection: args.collection,
       database: args.database,
     })


### PR DESCRIPTION
Task related to `insertOne` command was receiving a `document` argument instead of `pipeline`, which caused errors.

Fixes #3