### PR TITLE
Allow createCollection and dropCollection to return rather than throw error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ cy.dropCollection('start_new').then(res => {
 });
 ```
 
+`createCollection` and `dropCollection` have the option to `failSilently`.
+
+```
+cy.createCollection('existing_collection', { failSilently: true}).then(res => {
+    cy.log(res); // Error object if collection already exists
+});
+
+cy.dropCollection('nonexistent_collection', { failSilently: true}).then(res => {
+    cy.log(res); // Error object if collection doesn’t exist
+});
+```
+
 # Environment setup
 
 Add the following `env` properties in your `cypress.json` file:

--- a/src/commands/collection.ts
+++ b/src/commands/collection.ts
@@ -3,13 +3,14 @@ import { validate } from '../utils/validator';
 
 export function createCollection(
   collection: string,
-  options: { database: string }
+  options: { database?: string; noThrow?: boolean }
 ): Chainable {
   const args = {
     uri: Cypress.env('mongodb').uri,
     options: {
       database: options?.database || Cypress.env('mongodb').database,
       collection: collection,
+      noThrow: options?.noThrow ?? false,
     },
   };
 
@@ -22,13 +23,14 @@ export function createCollection(
 
 export function dropCollection(
   collection: string,
-  options: { database: string }
+  options: { database?: string; noThrow?: boolean }
 ): Chainable {
   const args = {
     uri: Cypress.env('mongodb').uri,
     options: {
       database: options?.database || Cypress.env('mongodb').database,
       collection: collection,
+      noThrow: options?.noThrow ?? false,
     },
   };
 

--- a/src/commands/collection.ts
+++ b/src/commands/collection.ts
@@ -3,14 +3,14 @@ import { validate } from '../utils/validator';
 
 export function createCollection(
   collection: string,
-  options: { database?: string; noThrow?: boolean }
+  options: { database?: string; failSilently?: boolean }
 ): Chainable {
   const args = {
     uri: Cypress.env('mongodb').uri,
     options: {
       database: options?.database || Cypress.env('mongodb').database,
       collection: collection,
-      noThrow: options?.noThrow ?? false,
+      failSilently: options?.failSilently ?? false,
     },
   };
 
@@ -23,14 +23,14 @@ export function createCollection(
 
 export function dropCollection(
   collection: string,
-  options: { database?: string; noThrow?: boolean }
+  options: { database?: string; failSilently?: boolean }
 ): Chainable {
   const args = {
     uri: Cypress.env('mongodb').uri,
     options: {
       database: options?.database || Cypress.env('mongodb').database,
       collection: collection,
-      noThrow: options?.noThrow ?? false,
+      failSilently: options?.failSilently ?? false,
     },
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,11 @@ declare global {
       ): Chainable<Subject>;
       createCollection(
         collection: string,
-        options?: { database: string }
+        options?: { database?: string; noThrow?: boolean }
       ): Chainable<Subject>;
       dropCollection(
         collection: string,
-        options?: { database: string }
+        options?: { database?: string; noThrow?: boolean }
       ): Chainable<Subject>;
       insertOne(document: Document, options?: MongoOptions): Chainable<Subject>;
       insertMany(
@@ -42,12 +42,14 @@ export interface MongoDetails {
   uri: string;
   options: MongoOptions;
   pipeline?: Document | Document[];
+  noThrow?: boolean;
 }
 
 export interface MongoOptions {
   collection?: string;
   database?: string;
   forceObjectId?: boolean;
+  noThrow?: boolean;
 }
 
 export const configurePlugin = async (on: Cypress.PluginEvents) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,11 @@ declare global {
       ): Chainable<Subject>;
       createCollection(
         collection: string,
-        options?: { database?: string; noThrow?: boolean }
+        options?: { database?: string; failSilently?: boolean }
       ): Chainable<Subject>;
       dropCollection(
         collection: string,
-        options?: { database?: string; noThrow?: boolean }
+        options?: { database?: string; failSilently?: boolean }
       ): Chainable<Subject>;
       insertOne(document: Document, options?: MongoOptions): Chainable<Subject>;
       insertMany(
@@ -42,14 +42,14 @@ export interface MongoDetails {
   uri: string;
   options: MongoOptions;
   pipeline?: Document | Document[];
-  noThrow?: boolean;
+  failSilently?: boolean;
 }
 
 export interface MongoOptions {
   collection?: string;
   database?: string;
   forceObjectId?: boolean;
-  noThrow?: boolean;
+  failSilently?: boolean;
 }
 
 export const configurePlugin = async (on: Cypress.PluginEvents) => {

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -12,7 +12,11 @@ export async function createCollection(args: MongoDetails) {
       })
       .catch((err) => {
         client.close();
-        throw err;
+        if (args.options.noThrow) {
+          return err;
+        } else {
+          throw err;
+        }
       });
   });
 }
@@ -29,7 +33,11 @@ export async function dropCollection(args: MongoDetails) {
       })
       .catch((err) => {
         client.close();
-        throw err;
+        if (args.options.noThrow) {
+          return err;
+        } else {
+          throw err;
+        }
       });
   });
 }

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -12,7 +12,7 @@ export async function createCollection(args: MongoDetails) {
       })
       .catch((err) => {
         client.close();
-        if (args.options.noThrow) {
+        if (args.options.failSilently) {
           return err;
         } else {
           throw err;
@@ -33,7 +33,7 @@ export async function dropCollection(args: MongoDetails) {
       })
       .catch((err) => {
         client.close();
-        if (args.options.noThrow) {
+        if (args.options.failSilently) {
           return err;
         } else {
           throw err;

--- a/test/cypress/integration/mongodb.spec.ts
+++ b/test/cypress/integration/mongodb.spec.ts
@@ -550,10 +550,22 @@ describe(
       });
     });
 
+    it('Should fail creating existing collection -- nothrow', () => {
+      cy.createCollection(collection_data.collection, { noThrow: true })
+        .its('codeName')
+        .should('equal', 'NamespaceExists');
+    });
+
     it('Should drop created collection', () => {
       cy.dropCollection(collection_data.collection).then((res) => {
         assert.equal(res, 'Collection dropped');
       });
+    });
+
+    it('Should fail dropping nonexistant collection -- nothrow', () => {
+      cy.dropCollection(collection_data.collection, { noThrow: true })
+        .its('codeName')
+        .should('equal', 'NamespaceNotFound');
     });
 
     it('Should fail when no collection name is provided', () => {

--- a/test/cypress/integration/mongodb.spec.ts
+++ b/test/cypress/integration/mongodb.spec.ts
@@ -620,7 +620,10 @@ describe(
       });
 
       it('Should fail deleting one document - incorrect pipeline', () => {
-        cy.on('fail', () => false);
+        cy.on('fail', (error) => {
+          if (error.message.includes('Filter must be an object')) return;
+          throw error;
+        });
         const pipeline = [{ id: 1 }];
         cy.deleteOne(pipeline).then(() => {
           throw new Error('Should fail with pipeline must be an object error');

--- a/test/cypress/integration/mongodb.spec.ts
+++ b/test/cypress/integration/mongodb.spec.ts
@@ -550,8 +550,8 @@ describe(
       });
     });
 
-    it('Should fail creating existing collection -- nothrow', () => {
-      cy.createCollection(collection_data.collection, { noThrow: true })
+    it('Should not fail creating existing collection', () => {
+      cy.createCollection(collection_data.collection, { failSilently: true })
         .its('codeName')
         .should('equal', 'NamespaceExists');
     });
@@ -562,8 +562,8 @@ describe(
       });
     });
 
-    it('Should fail dropping nonexistant collection -- nothrow', () => {
-      cy.dropCollection(collection_data.collection, { noThrow: true })
+    it('Should not fail dropping nonexistant collection', () => {
+      cy.dropCollection(collection_data.collection, { failSilently: true })
         .its('codeName')
         .should('equal', 'NamespaceNotFound');
     });
@@ -620,10 +620,7 @@ describe(
       });
 
       it('Should fail deleting one document - incorrect pipeline', () => {
-        cy.on('fail', (error) => {
-          if (error.message.includes('Filter must be an object')) return;
-          throw error;
-        });
+        cy.on('fail', () => false);
         const pipeline = [{ id: 1 }];
         cy.deleteOne(pipeline).then(() => {
           throw new Error('Should fail with pipeline must be an object error');

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -14,8 +14,9 @@
       }
     },
     "..": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "integrity": "sha512-w1RXQ8j3kAUqIJCsHTbg/qHX02BmMoUof/EWuubWP1QhS/YAz6t7Ic7SAKLEckL8HYKoWqDHgSrQyhz8iR1Dxg==",
+      "license": "MIT",
       "dependencies": {
         "mongodb": "4.2.1"
       },


### PR DESCRIPTION
> Please create feature requests for things you'd like to see.

Feature request/suggestion in the form of a proof-of-concept PR.

Motivation: I want to be able to clear collection(s) before testing, to ensure a consistent state.

```
  cy.dropCollection('collection_a') // but continue silently on NamespaceNotFound
  cy.dropCollection('collection_b') // ... ditto ...
```

The errors might be caught and discarded with ```cy.on('fail',``` but it means adding boilerplate to distinguish between expected and unexpected failures in each test, or maybe wrapping the commands in support/index.js.

This PR allows for:

```
  cy.dropCollection('collection', { noThrow: true })
    .then(resultOrError => {})
  cy.createCollection('collection', { noThrow: true })
    .then(resultOrError => {})
```

The methodology might be extended to the validate() errors and other commands, but my immediate need is for dropCollection when the collection doesn’t exist.