### PR TITLE
Cypress 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ profit
 
 # Supported and tested MongoDB versions
 
-4.4, 5.0
+4.4, 5.0, 6.0
 
 # Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-mongodb",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-mongodb",
-      "version": "5.1.3",
+      "version": "5.1.4",
       "license": "MIT",
       "dependencies": {
         "mongodb": "4.10.0"
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@faker-js/faker": "^7.5.0",
         "@types/node": "^18.11.9",
-        "cypress": "^11.2.0",
+        "cypress": "^12.3.0",
         "prettier": "^2.8.0",
         "typescript": "^4.9.3"
       }
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -615,7 +615,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -2423,9 +2423,9 @@
       }
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+      "integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@faker-js/faker": "^7.5.0",
     "@types/node": "^18.11.9",
-    "cypress": "^11.2.0",
+    "cypress": "^12.3.0",
     "prettier": "^2.8.0",
     "typescript": "^4.9.3"
   }


### PR DESCRIPTION
Seems to work fine with Cypress 12 and MongoDB 6. All that was needed was a version bump so that dependencies don't clash.